### PR TITLE
Add command line option to specify port numbers, adds docopt as dependency

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,29 @@
+#!/usr/bin/env python
 # -*- encoding: utf-8 -*-
+"""OAbot web interface
+
+Usage:
+  app.py [-p PORT| --port PORT]
+  app.py (-h | --help)
+  app.py --version
+
+Options:
+  -p, --port PORT   Mount the application on port PORT [default: 8000].
+  --version         Show version.
+  -h --help         Show this screen.
+
+"""
+__version__ = '0.0.1'
+
 from bottle import route, run, static_file, request, default_app
+from docopt import docopt
 from poc import *
 from poc import OABOT_APP_MOUNT_POINT
 
 
 @route('/')
 def home():
-    with open('templates/home.html','r') as f:
+    with open('templates/home.html', 'r') as f:
         homepage = f.read()
 
     homepage = homepage.replace('OABOT_APP_MOUNT_POINT', OABOT_APP_MOUNT_POINT)
@@ -18,13 +35,19 @@ def home():
 def css(fname):
     return static_file(fname, root='css/')
 
+
 @route('/process')
 def process():
     page_name = request.query.get('name')
     tpl = render_template(page_name)
     return tpl
 
+
 if __name__ == '__main__':
-	run(host='localhost', port=8000, debug=True)
+    arguments = docopt(__doc__, version=__version__)
+
+    port = arguments['--port']
+
+    run(host='localhost', port=port, debug=True)
 
 app = application = default_app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 wikiciteparser
 #pywikibot
 requests
+docopt


### PR DESCRIPTION
As per commit message.

You can mount the application on a different port with the `-p` option, for example:

``` bash
$ OABOT_DEV=1 python app.py -p 5555 
```

will bind the application to port `5555`.
