### PR TITLE
Simple article URL preview with iframe

### DIFF
--- a/templates/one-edit.html
+++ b/templates/one-edit.html
@@ -72,6 +72,11 @@
         <div id="preview-diff">
         </div>
 
+        <h3>URL preview</h3>
+        <div id="preview-target">
+        <iframe width="400" height="300" src="{{ proposed_edit.proposed_link }}"></iframe>
+        </div>
+
         {% else %}
         <p>No edit proposed for this page.</p>
         {% endif %}


### PR DESCRIPTION
Might not be pretty with some browsers or configurations (e.g. if
you automatically download the embedded PDFs) but for me it's enough
to save quite some time.

https://phabricator.wikimedia.org/T166284