### PR TITLE
Link Dissemin information for the DOI to aid policy compliance checks

### DIFF
--- a/wikirender.py
+++ b/wikirender.py
@@ -19,6 +19,7 @@ def wikirender(eval_ctx, wikicode):
     result = result.replace('href="/wiki/',
             'href="https://en.wikipedia.org/wiki/')
     result = result.replace('<a ','<a target="_blank" ')
+    result = result.replace('doi.org/','dissem.in/')
 
     if eval_ctx.autoescape:
         result = Markup(result) or wikicode


### PR DESCRIPTION
The publisher's version will still be available on the Dissemin page
itself. If the DOI is not available on Dissemin, not much harm is done.