### PR TITLE
Shorten label to just Toolforge

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -57,7 +57,7 @@
         <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=OABot">Bugs on Phabricator</a> -
         <a href="https://en.wikipedia.org/wiki/User_talk:Pintoch">Run by Pintoch</a> -
         <a href="https://association.dissem.in/index.html.en">A CAPSH project</a> -
-        <a href="https://tools.wmflabs.org/">Hosted on WMF Toolforge</a> -
+        <a href="https://tools.wmflabs.org/">Hosted on Toolforge</a> -
         Logo CC-BY-SA <a href="http://dougdworkin.com/">Doug Dworkin</a>
     </p>
 


### PR DESCRIPTION
Per https://wikitech.wikimedia.org/wiki/Portal:Toolforge that is the full name. :-)