### PR TITLE
Add 'dbconfig' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 wikiciteparser
 pywikibot
 requests
+dbconfig
 docopt
 unidecode
 subprocess32


### PR DESCRIPTION
Launching `app.py` I get the following error:
```bash
$ python app.py 
Traceback (most recent call last):
  File "app.py", line 42, in <module>
    from userstats import UserStats
  File "/media/cristian/data/extra/oabot/oabot/userstats.py", line 7, in <module>
    from dbconfig import get_engine
ImportError: No module named dbconfig
```
the module `dbconfig` needs to be installed, so I add it to `requirements.txt`.