### PR TITLE
Error correctly if zotero_cache_key.txt isn't present

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -22,10 +22,11 @@ excluded_templates = ['cite arxiv', 'cite web', 'cite news', 'cite book']
 #
 # Ask for an API key at  dev @ dissem . in
 #
-ZOTERO_CACHE_API_KEY = open('zotero_cache_key.txt','r').read().strip()
-if not ZOTERO_CACHE_API_KEY:
-    raise ValueError('Please provide a Zotero cache API key '+
-                    '(email dev @ dissem . in to get one.)')
+try:
+	ZOTERO_CACHE_API_KEY = open('zotero_cache_key.txt','r').read().strip()
+except IOError:
+	print('Please provide a Zotero cache API key '+
+          '(email dev @ dissem . in to get one)')
 
 
 


### PR DESCRIPTION
Per https://phabricator.wikimedia.org/T178982, if zotero_cache_key.txt wasn't present, Python errored (`no such file or directory`) before the more helpful error message was printed.