### PR TITLE
Update bottom links to Phabricator for clarity and parity

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -54,7 +54,8 @@
 
     <p class="center">
         <a href="https://github.com/dissemin/oabot">Code on GitHub</a> -
-        <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=OABot">Bugs on Phabricator</a> -
+        <a href="https://phabricator.wikimedia.org/tag/oabot">Open tasks</a> -
+        <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=OABot">Report a bug</a> -
         <a href="https://en.wikipedia.org/wiki/User_talk:Pintoch">Run by Pintoch</a> -
         <a href="https://association.dissem.in/index.html.en">A CAPSH project</a> -
         <a href="https://tools.wmflabs.org/">Hosted on Toolforge</a> -

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -34,10 +34,11 @@
 	
         <br/><br/>
     
-	<p><center><a href="https://github.com/dissemin/oabot">Code on GitHub</a> - 
-	   	 <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=OABot">Bugs on Phabricator</a> - 
-           	<a href="https://en.wikipedia.org/wiki/User_talk:Pintoch">Run by Pintoch</a> - 
-           	<a href="https://association.dissem.in/index.html.en">A CAPSH project</a> -
+	<p><center><a href="https://github.com/dissemin/oabot">Code on GitHub</a> -
+             <a href="https://phabricator.wikimedia.org/tag/oabot">Open tasks</a> -
+             <a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=OABot">Report a bug</a> -
+             <a href="https://en.wikipedia.org/wiki/User_talk:Pintoch">Run by Pintoch</a> -
+           	 <a href="https://association.dissem.in/index.html.en">A CAPSH project</a> -
 		<a href="https://tools.wmflabs.org/">Hosted on WMF Tool Labs</a></center>
 	 </p>
 	    


### PR DESCRIPTION
Previous 'bugs on phabricator' link went to a bug submission form, rather than linking to the actual bugs. Split this into 'report a bug' and 'open tasks' buttons for clarity, and updated stats.html and index.html to have the same buttons + text.