### PR TITLE
Fix InvalidUsage, was missing parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,7 +62,7 @@ app.jinja_env.filters['wikirender'] = wikirender.wikirender
 class InvalidUsage(Exception):
     status_code = 400
 
-    def __init__(self, message, status_code=None):
+    def __init__(self, message, status_code=None, payload=None):
         Exception.__init__(self)
         self.message = message
         if status_code is not None:

--- a/templates/change.html
+++ b/templates/change.html
@@ -56,6 +56,7 @@
         </ol>
            
         <h3>Actions</h3>
+        <small>This tool will perform edits using your Wikipedia account. Please ensure you understand the section of the copyright policy regarding the addition of links to copyright violating works (<a href="https://en.wikipedia.org/wiki/WP:COPYLINK">WP:COPYLINK</a>). Repeated violations may result in warnings or blocks.</small>
         <p>
         <span class="btn-group">
             <input type="button" onclick="window.location.href='{{ url_for('get_random_edit') }}'" class="btn btn-danger" value="Skip" />

--- a/templates/one-edit.html
+++ b/templates/one-edit.html
@@ -51,6 +51,7 @@
         <input type="hidden" size="100" name="{{ proposed_edit.orig_hash }}" value="{{ proposed_edit.proposed_change }}" />
        
         <h3>Actions</h3>
+        <small>This tool will perform edits using your Wikipedia account. Please ensure you understand the section of the copyright policy regarding the addition of links to copyright violating works (<a href="https://en.wikipedia.org/wiki/WP:COPYLINK">WP:COPYLINK</a>). Repeated violations may result in warnings or blocks.</small>
         <p>
         <span class="btn-group">
             <input type="button" accesskey="1" onclick="window.location.href='{{ url_for('get_random_edit') }}'" class="btn btn-danger" value="Skip" />


### PR DESCRIPTION
I'll still post PRs for most things that touch Flask code since I have little to no experience of it, especially while I don't have access to a fully functioning version of the tool.

Anyway, looks like you took this code from http://flask.pocoo.org/docs/0.12/patterns/apierrors/ but tje 'payload' parameter was missing so it errors out if you have, for example, a blank edit summary. Think this should fix, but untested.