### PR TITLE
Display Sherpa/Romeo information above proposed citations

### DIFF
--- a/src/oabot/static/css/style.css
+++ b/src/oabot/static/css/style.css
@@ -107,6 +107,46 @@ body {
     text-align: right;
     margin: 30px;
 }
+.circle-green {
+    height: 10px;
+    width: 10px;
+    display: block;
+    border: 1px solid black;
+    border-radius: 10px;
+    background: #09ba00;
+    display: inline-block;
+}
+.circle-orange {
+    height: 10px;
+    width: 10px;
+    display: block;
+    border: 1px solid black;
+    border-radius: 10px;
+    background: #ffc61c;
+    display: inline-block;
+}
+.circle-red {
+    height: 10px;
+    width: 10px;
+    display: block;
+    border: 1px solid black;
+    border-radius: 10px;
+    background: #ed4b23;
+    display: inline-block;
+}
+.sherparomeo {
+    border: 1px solid #888;
+    border-width: 2px;
+    border-radius: 5px;
+    display: inline-block;
+    padding: 5px;
+    margin-bottom: 5px;
+}
+.sherparomeonote {
+    margin-top: 5px;
+    margin-bottom: 3px;
+    font-size: 0.9em;
+}
 .startbutton {
     max-width: 500px;
     margin: 0 auto;

--- a/src/oabot/static/css/style.css
+++ b/src/oabot/static/css/style.css
@@ -107,32 +107,22 @@ body {
     text-align: right;
     margin: 30px;
 }
-.circle-green {
+.circle {
     height: 10px;
     width: 10px;
     display: block;
     border: 1px solid black;
-    border-radius: 10px;
-    background: #09ba00;
+    border-radius: 10px;   
     display: inline-block;
+}
+.circle-green {
+    background: #09ba00;
 }
 .circle-orange {
-    height: 10px;
-    width: 10px;
-    display: block;
-    border: 1px solid black;
-    border-radius: 10px;
     background: #ffc61c;
-    display: inline-block;
 }
 .circle-red {
-    height: 10px;
-    width: 10px;
-    display: block;
-    border: 1px solid black;
-    border-radius: 10px;
     background: #ed4b23;
-    display: inline-block;
 }
 .sherparomeo {
     border: 1px solid #888;

--- a/src/oabot/templates/change.html
+++ b/src/oabot/templates/change.html
@@ -1,11 +1,13 @@
 <!doctype html>
 {% macro circle_color(policy) -%}
     {% if policy == 'can' %}
-        <div class="circle-green"></div> Allowed
+        <div class="circle circle-green"></div> Allowed
     {% elif policy == 'restricted' %}
-        <div class="circle-orange"></div> Restricted
+        <div class="circle circle-orange"></div> Restricted
     {% elif policy == 'cannot' %}
-        <div class="circle-red"></div> Forbidden
+        <div class="circle circle-red"></div> Forbidden
+    {% else %}
+        <div class="circle"></div> Unknown
     {% endif %}
 {%- endmacro %}
 <html>

--- a/src/oabot/templates/change.html
+++ b/src/oabot/templates/change.html
@@ -1,4 +1,13 @@
 <!doctype html>
+{% macro circle_color(policy) -%}
+    {% if policy == 'can' %}
+        <div class="circle-green"></div> Allowed
+    {% elif policy == 'restricted' %}
+        <div class="circle-orange"></div> Restricted
+    {% elif policy == 'cannot' %}
+        <div class="circle-red"></div> Forbidden
+    {% endif %}
+{%- endmacro %}
 <html>
     <head>
         <title> OAbot: {{ page_name }}</title>
@@ -46,6 +55,14 @@
         <ol>
 
         {%  for template_edit in proposed_edits %}
+            <div class="sherparomeo">
+                <b>Copyright guidance</b><br>
+                <div class="sherparomeonote">Are the authors of this citation permitted to archive the...</div>
+                Preprint: {{ circle_color( template_edit.policy.preprint ) }}<br>
+                Postprint: {{ circle_color( template_edit.policy.postprint ) }}<br>
+                Published: {{ circle_color( template_edit.policy.published ) }}<br>
+                <div class="sherparomeonote">Data from <i>Sherpa/Romeo</i></div>
+            </div>
             <li id="{{ template_edit.index +1 }}">
             <div class="wiki">{{ template_edit.orig_string|wikirender }}</div>
             <p>

--- a/src/oabot/templates/one-edit.html
+++ b/src/oabot/templates/one-edit.html
@@ -1,4 +1,13 @@
 <!doctype html>
+{% macro circle_color(policy) -%}
+    {% if policy == 'can' %}
+        <div class="circle-green"></div> Allowed
+    {% elif policy == 'restricted' %}
+        <div class="circle-orange"></div> Restricted
+    {% elif policy == 'cannot' %}
+        <div class="circle-red"></div> Forbidden
+    {% endif %}
+{%- endmacro %}
 <html>
     <head>
         <title>OAbot: {{ page_name }}</title>
@@ -44,6 +53,15 @@
         <h3>Citation</h3>
         <form id="edit-form" action="{{ url_for('perform_edit') }}" method="POST"> 
         <input type="hidden" name="name" value="{{ page_name }}" />
+
+        <div class="sherparomeo">
+            <b>Copyright guidance</b><br>
+            <div class="sherparomeonote">Are the authors of this citation permitted to archive the...</div>
+            Preprint: {{ circle_color( proposed_edit.policy.preprint ) }}<br>
+            Postprint: {{ circle_color( proposed_edit.policy.postprint ) }}<br>
+            Published: {{ circle_color( proposed_edit.policy.published ) }}<br>
+            <div class="sherparomeonote">Data from <i>Sherpa/Romeo</i></div>
+        </div>
 
         <div class="wiki">{{ proposed_edit.orig_string|wikirender }}</div>
         <p>

--- a/src/oabot/templates/one-edit.html
+++ b/src/oabot/templates/one-edit.html
@@ -1,11 +1,13 @@
 <!doctype html>
 {% macro circle_color(policy) -%}
     {% if policy == 'can' %}
-        <div class="circle-green"></div> Allowed
+        <div class="circle circle-green"></div> Allowed
     {% elif policy == 'restricted' %}
-        <div class="circle-orange"></div> Restricted
+        <div class="circle circle-orange"></div> Restricted
     {% elif policy == 'cannot' %}
-        <div class="circle-red"></div> Forbidden
+        <div class="circle circle-red"></div> Forbidden
+    {% else %}
+        <div class="circle"></div> Unknown
     {% endif %}
 {%- endmacro %}
 <html>
@@ -54,14 +56,16 @@
         <form id="edit-form" action="{{ url_for('perform_edit') }}" method="POST"> 
         <input type="hidden" name="name" value="{{ page_name }}" />
 
+        {% if proposed_edit.policy.preprint %}
         <div class="sherparomeo">
             <b>Copyright guidance</b><br>
             <div class="sherparomeonote">Are the authors of this citation permitted to archive the...</div>
             Preprint: {{ circle_color( proposed_edit.policy.preprint ) }}<br>
             Postprint: {{ circle_color( proposed_edit.policy.postprint ) }}<br>
             Published: {{ circle_color( proposed_edit.policy.published ) }}<br>
-            <div class="sherparomeonote">Data from <i>Sherpa/Romeo</i></div>
+            <div class="sherparomeonote">Data from <i><a href="http://www.sherpa.ac.uk/romeo">Sherpa/Romeo</a>.</i></div>
         </div>
+        {% endif %}
 
         <div class="wiki">{{ proposed_edit.orig_string|wikirender }}</div>
         <p>


### PR DESCRIPTION
I'm 100% certain this was a bad way to implement this, but as far as I could test it, it works.

We should probably also link to the full Sherpa/Romeo listing from the guidance box, and/or provide some further explanation of what the information means.