### PR TITLE
Use a stricter regex for arXiv identifiers

### DIFF
--- a/src/oabot/arguments.py
+++ b/src/oabot/arguments.py
@@ -100,7 +100,7 @@ template_arg_mappings = [
         custom_access=True),
     ArgumentMapping(
         'arxiv',
-        r'https?://arxiv\.org/(abs|pdf)/(.*)(.pdf)?',
+        r'https?://arxiv\.org/(abs|pdf)/(\d+\.[\dv]+)(\.pdf)?',
         group_id=2,
         alternate_names=['eprint'],
         always_free=True),


### PR DESCRIPTION
See https://arxiv.org/help/arxiv_identifier
Does not check the number of digits, but avoids a greedy match of ".pdf".

Fixes https://phabricator.wikimedia.org/T187791

Bug: T187791