### PR TITLE
Fix bot flag

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -125,7 +125,7 @@ def edit_wiki_page(page_name, content, access_token, summary=None, bot=False):
         'watchlist': 'nochange',
     }
     if bot:
-        data['bot'] = ''
+        data['bot'] = '1'
     r = requests.post('https://en.wikipedia.org/w/api.php', data=data,
             auth=auth)
     r.raise_for_status()


### PR DESCRIPTION
requests appears to drop empty values from the data, and I’m not sure what MediaWiki does with them either. Using bot=1 seems to be the standard way to set the flag.

See also https://github.com/OpenRefine/OpenRefine/issues/1612#issuecomment-390315891 ff.