### PR TITLE
Add pyOpenSSL as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests_oauthlib
 sqlalchemy
 configparser
 mysql
+pyOpenSSL


### PR DESCRIPTION
I download the repo and started from a fresh [virtualenv][1] and I was getting this error:
```
$ python app.py    
Traceback (most recent call last):
  File "app.py", line 46, in <module>
    import urllib3.contrib.pyopenssl
  File "/home/cristian/.virtualenvs/oabot2/lib/python2.7/site-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
ImportError: No module named OpenSSL.SSL
```

Install the modeule `pyOpenSSL` solved the problem:
```
$ pip install pyopenssl   
```

[1]: http://docs.python-guide.org/en/latest/dev/virtualenvs/