### PR TITLE
Blacklist the "access restricted" CSIC URLs

### DIFF
--- a/src/oabot/ranking.py
+++ b/src/oabot/ranking.py
@@ -61,6 +61,8 @@ def sort_links(urls):
     return sorted(urls, key=link_rank)
 
 def is_blacklisted(url):
+    if '/accesoRestringido.pdf' in url:
+        return True
     if extract_domain(url) in domain_blacklist:
         return True
     else:


### PR DESCRIPTION
* Avoid suggesting csic.es URLs which are just a waste of time, like
  https://digital.csic.es/bitstream/10261/73732/1/accesoRestringido.pdf
* This should be fixed upstream, but meanwhile they pollute some 1.3 %
  of the cached suggestions for no good reasons.