### PR TITLE
Add a modicum of sleep between Unpaywall requests

### DIFF
--- a/src/oabot/main.py
+++ b/src/oabot/main.py
@@ -241,6 +241,7 @@ def get_oa_link(paper):
             try:
                 req = requests.get('http://api.unpaywall.org/v2/:{}'.format(doi), params={'email':email}, timeout=10)
                 resp = req.json()
+                sleep(0.1)
             except ValueError:
                 sleep(10)
                 attempts += 1


### PR DESCRIPTION
* Unpaywall asks to not cross 100k requests/day.
* Articles with many references may result in hundreds of requests
  being made in few seconds.