### PR TITLE
Redirect immediately to proposed edit if logged in

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -97,6 +97,8 @@ def index():
         'username' : flask.session.get('username', None),
         'success' : flask.request.args.get('success'),
     }
+    if context['username']:
+        return flask.redirect(flask.url_for('get_random_edit'))
     return flask.render_template("index.html", **context)
 
 def edit_wiki_page(page_name, content, access_token, summary=None, bot=False):


### PR DESCRIPTION
Saves the user a click when already logged in to the English Wikipedia
and to OAbot. Helps repeat users until the cookie on Tools expires.

Bug: https://phabricator.wikimedia.org/T166280