### PR TITLE
Set hdl-access=free when adding a handle identifier

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -259,12 +259,15 @@ def make_new_wikicode(text, form_data, page_name):
         proposed_addition = form_data.get(edit.orig_hash)
         user_checked = form_data.get(edit.orig_hash+'-addlink')
         if proposed_addition and user_checked == 'checked':
-            try:
-                edit.update_template(proposed_addition)
-                change_made = True
-            except ValueError:
-                app.logger.exception('update_template failed on {}'.format(page_name))
-                pass # TODO report to the user
+            # Go through one or more suggestions separated by pipe
+            for proposed_parameter in proposed_addition.split("|"):
+                try:
+                    # Get the new wikitext for the template with this parameter added
+                    edit.update_template(proposed_parameter)
+                    change_made = True
+                except ValueError:
+                    app.logger.exception('update_template failed on {}'.format(page_name))
+                    pass # TODO report to the user
     return unicode(wikicode), change_made
 
 

--- a/src/oabot/main.py
+++ b/src/oabot/main.py
@@ -155,6 +155,8 @@ class TemplateEdit(object):
                 self.proposed_change = 'id={{%s|%s}}' % (argmap.name,match)
             else:
                 self.proposed_change = '%s=%s' % (argmap.name,match)
+                if argmap.name == 'hdl':
+                    self.proposed_change += "|hdl-access=free"
             break
 
     def update_template(self, change):

--- a/src/tests/templateedit.py
+++ b/src/tests/templateedit.py
@@ -46,6 +46,13 @@ crowdsourcing|url=http://www.sciencedirect.com/science/article/pii/S000768131400
         """)
         self.assertNotEquals("url=https://naldc.nal.usda.gov/naldc/download.xhtml?id=42375&content=PDF", edit.proposed_change)
 
+    # Test add handle and hdl-access
+    def test_add_hdl(self):
+        edit = self.propose_change("""
+{{cite journal|doi=10.1006/mcpr.2001.0377|pmid=11851384|title=C306A single nucleotide polymorphism in the human CEBPD gene that maps at 8p11.1–p11.2|journal=Molecular and Cellular Probes|volume=15|issue=6|pages=395–397|year=2002|last1=Angeloni|first1=Debora|last2=Lee|first2=Joshua D.}}
+        """)
+        self.assertEquals("hdl=11382/3170|hdl-access=free", edit.proposed_change)
+
     def test_uppercase(self):
         edit = self.propose_change("""
 {{Cite journal|last=Prpić|first=John|last2=Shukla|first2=Prashant P.|last3=Kietzmann|first3=Jan H.|last4=McCarthy|first4=Ian P.|date=2015-01-01|title=How to work a crowd: Developing crowd capital through


### PR DESCRIPTION
Adds the ability to propose more than one parameter change at a time,
for now only for newly added links.

Bug: T228632