### PR TITLE
Also blacklist orbit.dtu.dk

### DIFF
--- a/src/oabot/ranking.py
+++ b/src/oabot/ranking.py
@@ -104,6 +104,7 @@ domain_blacklist = [
     'ucpress.edu',
     # Broken repositories
     'library.tue.nl',
+    'orbit.dtu.dk',
 ]
 
 domain_re = re.compile(r'\s*(https?|ftp)://(([a-zA-Z0-9-_]+\.)+[a-zA-Z]+)(:[0-9]+)?/?')


### PR DESCRIPTION
It's some proprietary pseudo-repository which created hundreds of
suggestions which don't actually have full text.