### PR TITLE
Always report success for oabot_refresh, no need to retry

### DIFF
--- a/oabot_refresh.sh
+++ b/oabot_refresh.sh
@@ -10,3 +10,5 @@ cd ~/www/python/
 for title in $( find ~/www/python/src/cache -maxdepth 1 -type f -mtime -14 -name "*json" -printf "%f\n" | sed 's,#,/,g' | sed 's,.json,,g' | sort | shuf ); do bash oabot_prefill_single.sh "$title" ; done
 cd ~/www/python/src/
 ~/www/python/venv/bin/python bot.py "(arxiv|pmc|pmid|doi|hdl)"
+# Failure is not an option
+exit 0


### PR DESCRIPTION
Kubernetes might be trying a bit too hard to repeat the job when there
was some failure, but it's expected that bot.py will always encounter
some error or exception (at least the {{nobots}} pages).